### PR TITLE
XRWH-29 Removed unused class

### DIFF
--- a/plugins/rocks.xml.webhelp/xsl/topic.xsl
+++ b/plugins/rocks.xml.webhelp/xsl/topic.xsl
@@ -212,7 +212,7 @@
     </xsl:template>
 
     <xsl:template match="*" mode="addContentToHtmlBodyElement">
-        <article xsl:use-attribute-sets="article" id="topic-article" class="topic-article">
+        <article xsl:use-attribute-sets="article" id="topic-article">
             <xsl:attribute name="aria-labelledby">
                 <xsl:apply-templates select="*[contains(@class,' topic/title ')] |
                                        self::dita/*[1]/*[contains(@class,' topic/title ')]"


### PR DESCRIPTION
I couldn't find anything for the "Cleanup topic article container" ticket except removing an unused class. 
Please note that attribute-set "article" is attribute class from HTML5 plugin which ads an attribute role="article"