### PR TITLE
XRWH-115 Count TOC topics indent for 7+ levels.

### DIFF
--- a/plugins/rocks.xml.webhelp/xsl/nav.xsl
+++ b/plugins/rocks.xml.webhelp/xsl/nav.xsl
@@ -75,6 +75,12 @@
                             </xsl:variable>
                             <a>
                                 <xsl:attribute name="href" select="$current-href-fixed"/>
+
+                                <!-- Add left padding to TOC topics with levels greater than 6 (levels 1-6 are handled with CSS) -->
+                                <xsl:if test="$liLevel gt 6">
+                                    <xsl:attribute name="style" select="concat('padding-left: ', $liLevel + 0.5, 'em')"/>
+                                </xsl:if>
+
                                 <xsl:value-of select="$title"/>
                             </a>
                         </xsl:when>


### PR DESCRIPTION
To prevent a page from glitching, and do not overload the client device with JS/jQuery code, left padding for 7+ levels in TOC is counted in XSLT transformation. 

Examle: http://uarnet.intelliarts.com/vkrupa/vkrupa/GUID-38559484-0C8F-4A64-9B9E-DDB9494267D1.html