### PR TITLE
XRWH-154 Fix for missing prev buttons when if ancestor topicref don't have @href.

### DIFF
--- a/plugins/rocks.xml.webhelp/xsl/topic.xsl
+++ b/plugins/rocks.xml.webhelp/xsl/topic.xsl
@@ -149,6 +149,11 @@
                                 <xsl:with-param name="prev-topicref" select="$ancestor-topicref"/>
                             </xsl:call-template>
                         </xsl:when>
+                        <xsl:when test="$preceding-topicref/@href">
+                            <xsl:call-template name="insertNavPrevButton">
+                                <xsl:with-param name="prev-topicref" select="$preceding-topicref"/>
+                            </xsl:call-template>
+                        </xsl:when>
                     </xsl:choose>
 
                     <xsl:choose>
@@ -286,6 +291,11 @@
                                 <xsl:when test="$ancestor-topicref/@href">
                                     <xsl:call-template name="insertNavPrevButton">
                                         <xsl:with-param name="prev-topicref" select="$ancestor-topicref"/>
+                                    </xsl:call-template>
+                                </xsl:when>
+                                <xsl:when test="$preceding-topicref/@href">
+                                    <xsl:call-template name="insertNavPrevButton">
+                                        <xsl:with-param name="prev-topicref" select="$preceding-topicref"/>
                                     </xsl:call-template>
                                 </xsl:when>
                             </xsl:choose>


### PR DESCRIPTION
Example: https://xslt-dev.intelliarts.com/vkrupa/GUID-D54E1162-4B98-452B-9CA7-03F8526A5255.html