### PR TITLE
Xrwh 171 topic pages desktop remove bugs with search icon in the icons container

### DIFF
--- a/plugins/rocks.xml.webhelp/resources/css/topic.css
+++ b/plugins/rocks.xml.webhelp/resources/css/topic.css
@@ -377,13 +377,12 @@ h6.title {
 
 .right-buttons-container {
     height: 40px;
-    width: 136px;
-    transition: all ease-in-out .1s;
+    max-width: 136px;
+    text-align: right;
 }
 
 .main-button-container-wrapper.is-sticky .right-buttons-container {
-    width: 208px;
-    transition: all ease-in-out .1s;
+    max-width: 208px;
 }
 
 .main-button-container .dropdown-download {


### PR DESCRIPTION
In this PR I pushed changes that fix issues when the right buttons container was too wide if Save to google drive button is turned off.

Examples:
https://xslt-dev.intelliarts.com/vkrupa/GUID-B6E7D16B-E4CB-461F-9624-4DA173CD1C85.html
https://xslt-dev.intelliarts.com/vkrupa2/GUID-B6E7D16B-E4CB-461F-9624-4DA173CD1C85.html